### PR TITLE
fix(policyengine): add old releases to ensure plugin is found

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2,7 +2,7 @@
   {
     "id": "Armory.PolicyEngine",
     "description": "This plugin provides support for validating pipelines with the policy engine.",
-    "provider": "https://github.com/claymccoy",
+    "provider": "https://github.com/armory-io",
     "releases": [
       {
         "version": "0.2.1",
@@ -10,6 +10,177 @@
         "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
         "sha512sum": "408f35ee9d1483d10942d4f29ff61ca715c02c9334227291feaa8f8fa4a8bb099650887bb74bbfa9c2a3d2f68a4a1f93e20a82608fa4b130ec6ffbe97d082079",
         "url": "https://github.com/armory-plugins/pluginRepository/releases/download/v0.2.1-policy-engine/policy-engine-v0.2.1.zip"
+      },
+      {
+        "version": "0.2.1-rc",
+        "date": "2022-03-09T20:27:49.491693Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "3c095045e4688ddb5150d13dd5decea69faf15aa8e6d96fb57afe38ec1e73857ee889d4d1a421461571acb479524c484eb7ebb0036ae91b2eac78e780dca122d",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.2.1-rc/policy-engine-v0.2.1-rc.zip"
+      },
+      {
+        "version": "0.2.0",
+        "date": "2021-11-10T22:24:59.183404Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "fc88f347690760a9efad123a7a7700eed998388e34f715c33af0b52b620de1ac0280cbfec3a4ca0bd2bb112fbbd86d512b32d8e512854afdc5e666ca02067ed3",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.2.0/policy-engine-v0.2.0.zip"
+      },
+      {
+        "version": "0.2.0-rc",
+        "date": "2021-11-05T15:53:56.591789Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "eac695bb5034d36dbd252a7fc81987e992106f7bc9fb1c19f0b49ab8f2a8bbfdc71c901f227df1d88fb2f7811822fc8cf8697ad129cab663acc144ea53a8876e",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.2.0-rc/policy-engine-v0.2.0-rc.zip"
+      },
+      {
+        "version": "0.1.6",
+        "date": "2021-06-21T14:15:36.393922Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "9a8e3638c6976b5ea18c47670c5ef39dafbc1c5d18615d8df0ae7883794fe97d33c01076d03b10816e6d11dd50a9eab680b0940f2e12a58e481edab677098fa7",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.1.6/policy-engine-v0.1.6.zip"
+      },
+      {
+        "version": "0.1.5",
+        "date": "2021-06-11T20:17:10.172959Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "b1eda2a786fd84cd4edcdc71197723481c2cd14f55e4b9661f9184c94d41b10f72c95c1c3ffe03042126f57f3cd93dad199a8c8e5722294992b2c6f4b11b0aa4",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.1.5/policy-engine-v0.1.5.zip"
+      },
+      {
+        "version": "0.1.4",
+        "date": "2021-06-02T20:51:23.314652Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "f8071845d1a09c5e674179ae885e8bbee6818ae868093abe408aaf9dd30ce739952d81a7de6a612d3935876553ac42f0371962df25b525b89fc4ddee141c434d",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.1.4/policy-engine-v0.1.4.zip"
+      },
+      {
+        "version": "0.1.3",
+        "date": "2021-05-28T16:57:56.414206Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "7f21e489ed4f828dfb25e0303d855262cca839e426471fd28be88f5df69d8daaf9946ebfff7341b33d89e0d05f1dcacbf9da5be774f8c6bad293a9d06874f600",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.1.3/policy-engine-v0.1.3.zip"
+      },
+      {
+        "version": "0.1.2",
+        "date": "2021-05-27T20:36:10.256138Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "6a2e5d941807e91027607769fefda12193806964640646c5d3b1bb9dd5322c46a07b3ca759e949ce321f972239f58eccd0f3e582a24b48a79be9818be26e0d79",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.1.2/policy-engine-v0.1.2.zip"
+      },
+      {
+        "version": "0.1.1",
+        "date": "2021-05-26T16:55:33.198107Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "cbdf66a4cd192cde7caed9c7f91c1ce97466c4c8baa05b10e1aa2d25f8a9a2ea079989792b8efaaeb132557069105a98ddc214e5afbd91ebee620e9a153ed56d",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.1.1/policy-engine-v0.1.1.zip"
+      },
+      {
+        "version": "0.1.0",
+        "date": "2021-05-21T20:38:19.871895Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "c279430c0e637d157b6c17eaab2c6c029dd599f9ddce96979b530aba12e0b625528127cfccf8665634a433fbccd4a6a6e4ff13c71a7baa098da3658185179058",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.1.0/policy-engine-v0.1.0.zip"
+      },
+      {
+        "version": "0.0.27",
+        "date": "2021-05-19T14:33:59.114156Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0,deck>=0.0.0",
+        "sha512sum": "cf0d7a32d950eef84c4a09926adfcfc6f2028b805fef0d31243f635d42993412ddca361f5d2f605090b385fa6721e6220108a08fa2cd1b4a87bc2a399490b716",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.0.27/policy-engine-v0.0.27.zip"
+      },
+      {
+        "version": "0.0.25",
+        "date": "2021-05-05T17:44:05.044225Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0",
+        "sha512sum": "c1e9c07e1e42ecc2e3c54ba30c9a6fc06f0b7efd0680f38bca899bae8a741163b85ab4d2bd51eeb03bd29e5fc94928989b1ff582c167d0ff2f53830b587a33e5",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.0.25/policy-engine-v0.0.25.zip"
+      },
+      {
+        "version": "0.0.24",
+        "date": "2021-05-04T22:17:08.855147Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,gate>=0.0.0,orca>=0.0.0",
+        "sha512sum": "b02be7ec6e8c5f8df93ee8fe558937eb427eec9abda68efc4863db8f070e14fed21051ef836b2cc82d0c9598bd5bf6c7104ce5a6e84f6cb47c451d51d66428d8",
+        "url": "https://github.com/armory-plugins/policy-engine/releases/download/v0.0.24/policy-engine-v0.0.24.zip"
+      },
+      {
+        "version": "0.0.16",
+        "date": "2020-08-14T16:24:45.145Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "997d0f7f8b08b3ba61d82c55aacb95d4f8269b9fee0be1a52fc0278e983c2e0a013811d9733a53f14856e2149cabbd701b6ec482a68af7b996cbdc9e02217ab3",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.16/policy-engine-v0.0.16.zip"
+      },
+      {
+        "version": "0.0.15",
+        "date": "2020-08-14T14:52:28.932Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "3f1162e59555e1ef4c4a9a6e832ece130786c7715a49cd5b6cb47eddb07de5834b7261cb0c624c6c8268f75d4495df98133c7c8524fe1d97f0d2e1ac41081724",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.15/policy-engine-v0.0.15.zip"
+      },
+      {
+        "version": "0.0.14-rc3",
+        "date": "2020-07-17T16:10:04.499Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "c00d52d5c93036ae08bc0cf3d9913236c26568e9baf05c7314f15dc29616c7493517ac3dbddbfec2dfcc2b3833ecf0fe338ae73cb6ce753bf75430285283c362",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.14-rc3/policy-engine-v0.0.14-rc3.zip"
+      },
+      {
+        "version": "0.0.13",
+        "date": "2020-06-24T15:49:45.918Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "0eb50dae976a7ddeb3e8cec262a5e19524b61395ccf68c73da53ab8d864318ce2bbba968ec2c1e15f92fd52f40b1b3685e519c079773a7ad9c8757a814320477",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.13/policy-engine-v0.0.13.zip"
+      },
+      {
+        "version": "0.0.12",
+        "date": "2020-06-08T16:17:48.719Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "e776fd0fdf63f7f8c43711d476fed68594a5dc045857c002c03a77f5a5ec986fe066e136f1185fc1c0fd804c02e583321f33bcae1eccc3187b3a023718eebc84",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.12/policy-engine-v0.0.12.zip"
+      },
+      {
+        "version": "0.0.11",
+        "date": "2020-06-05T17:39:40.219Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "7e4ad66bc842970f9388d2edf61659fa9bfd2e646c604bd8379330c3a5c0a75c1f36a03fe2337fce1fb0c6d1f319f723074e209aec00b9dff7cd84fff64cd0e2",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.11/policy-engine-v0.0.11.zip"
+      },
+      {
+        "version": "0.0.10",
+        "date": "2020-05-26T14:41:42.663Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "a1ab74b39e21c895d4e1926d5416abc61b934558ee468c27de3190f27eabde6330f6607fa632300d4c02bf6ced49499c619f737be06798f59d84a0db1ce8a85d",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.10/policy-engine-v0.0.10.zip"
+      },
+      {
+        "version": "0.0.9",
+        "date": "2020-05-18T20:23:11.875Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "c7b1ae4ced6efc8f749e132f15ad510eb1a3da8b329478d9f9bc75ee0c5b570b650f3373fbabd3984ac115218d09b5c3f12fd8305e86aa76c7af6d4d54ea3f77",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.9/policy-engine-v0.0.9.zip"
+      },
+      {
+        "version": "0.0.8",
+        "date": "2020-05-08T20:02:57.943Z",
+        "requires": "clouddriver>=0.0.0,front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "00bc8c0e565aa982b63cb4bf38336f822006f0fedb07f078170dbacedd246e311b984837a24b592057c5bb1c11929a2ecb2688a6b192374a802ba91dd149cf94",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.8/policy-engine-v0.0.8.zip"
+      },
+      {
+        "version": "0.0.7",
+        "date": "2020-05-05T20:27:24.526Z",
+        "requires": "front50>=0.0.0,orca>=0.0.0",
+        "sha512sum": "afe296681a7aef6483f3c516676f7a8491fa661761f833d2ac1bd4483847a318901411ec4c4d4c62d4b05fba280a9ea91619016536c2a876c9d4f85d11fa28a5",
+        "state": "RELEASE",
+        "url": "https://github.com/armory-plugins/policy-engine-releases/releases/download/v0.0.7/policy-engine-v0.0.7.zip"
       }
     ]
   },


### PR DESCRIPTION
This adds metadata for Policy Engine releases < 0.2.1. 

Policy Engine was previously releasing to the `policy-engine-releases` repo. We recently migrated PE to instead publish to `armory-plugins/pluginRepository`. After doing so a bug in the plugin framework was discovered where Spinnaker will only look for a plugin release in the first repository to include the target plugin.  In this case, since older releases of PE were not listed in `pluginRepository`, specifying an older version of PE in the Spinnaker configuration would cause a failure. 

Note, this only happens when 2+ repositories are configured which include the same plugin id, and the target release version fails to appear in the plugins.json for the first repository Spinnaker looks at. 