### PR TITLE
fix(plugin.json): AWSCATs url fix

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -725,7 +725,7 @@
         "date": "2022-10-06T22:22:20.804685Z",
         "requires": "clouddriver>=0.0.0,gate>=0.0.0",
         "sha512sum": "6ec4ecba2c65910db131666e46e26a165f30de827f2af474a4efd3cd45c840d0e60f146ff06ff45bb225697f877133b512da35dff75bc72aad964639a6cfe23b",
-        "url": "https://github.com/armory-plugins/cache-aws-agents-on-event-releases/releases/download/v0.1.0/cache-aws-agents-on-event-v0.1.0.zip"
+        "url": "https://github.com/armory-plugins/cache-aws-agents-on-event/releases/download/v0.1.0/cache-aws-agents-on-event-v0.1.0.zip"
       }
     ]
   }


### PR DESCRIPTION
An error in the release workflow added an extra -release to the AWSCATsOnEvent plugin url