### PR TITLE
fix(k8sCustomStatusCheck) the url of the new version 2.0.3 pointing t…

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -750,7 +750,7 @@
         "requires": "clouddriver>=0.0.0",
         "sha512sum": "302e8bab55c8daf333f2fa6747d3a2543edb1810af3ab11dcce057410686ce66489c55abe3a1be2c1e2504c92566aed71fae00aaefdc91e56416e1e52b2d7f3e",
         "state": "",
-        "url": "https://github.com/armory-plugins/pluginRepository/releases/download/v2.0.3/k8s-custom-resource-status-v2.0.3.zip"
+        "url": "https://github.com/armory-plugins/pluginRepository/releases/download/v2.0.3-k8s-custom-resource-status/k8s-custom-resource-status-v2.0.3.zip"
       },
       {
         "version": "2.0.2",

--- a/plugins.json
+++ b/plugins.json
@@ -750,7 +750,7 @@
         "requires": "clouddriver>=0.0.0",
         "sha512sum": "302e8bab55c8daf333f2fa6747d3a2543edb1810af3ab11dcce057410686ce66489c55abe3a1be2c1e2504c92566aed71fae00aaefdc91e56416e1e52b2d7f3e",
         "state": "",
-        "url": "https://github.com/armory-plugins/k8s-custom-resource-status/releases/download/v2.0.3/k8s-custom-resource-status-v2.0.3.zip"
+        "url": "https://github.com/armory-plugins/pluginRepository/releases/download/v2.0.3/k8s-custom-resource-status-v2.0.3.zip"
       },
       {
         "version": "2.0.2",


### PR DESCRIPTION
…o the k8sCustomStatusCheck internal repo instead of the pluginRepository

the URL of the new version 2.0.3 was pointing to the k8sCustomStatusCheck internal repo instead of the pluginRepository  making clouddriver to failed when trying to download the V2.0.3