### PR TITLE
fix(K8sCustomResourceStatus): fixing url for version 3.0.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -758,7 +758,7 @@
         "requires": "clouddriver>=0.0.0",
         "sha512sum": "9fc8ef67852da4ff7f184082d5051759b22395b59f277a596c99fe2e4d9969387757132535b46bdf2f9ac20b8a0a83b03a4ca6d78167f2aed40af54079b30d6a",
         "state": "",
-        "url": "https://github.com/armory-plugins/k8s-custom-resource-status/releases/download/v3.0.0/k8s-custom-resource-status-v3.0.0.zip"
+        "url": "https://github.com/armory-plugins/pluginRepository/releases/download/v3.0.0-k8s-custom-resource-status/k8s-custom-resource-status-v3.0.0.zip"
       },
       {
         "version": "2.0.3",


### PR DESCRIPTION
The plugin K8sCustomResourceStatus is private, we created a new release in this repository and uploaded the asset manually
https://github.com/armory-plugins/pluginRepository/releases/tag/v3.0.0-k8s-custom-resource-status